### PR TITLE
Remove linting from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ install_test: ## Install the 'dev, test and extras' dependencies
 
 .PHONY: install_deps
 install_deps: ## Install all dependencies
-	@poetry install --with=development,linting,testing,docs
+	@poetry install --with=development,testing,docs
 
 .PHONY: install_ruff
 install_ruff: ## Install ruff for use within IDE
@@ -16,7 +16,7 @@ install_ruff: ## Install ruff for use within IDE
 
 .PHONY: update_deps
 update_deps: ## Update dependencies
-	@poetry update --with=development,linting,testing,docs
+	@poetry update --with=development,testing,docs
 
 .PHONY: test
 test: ## Run all tests


### PR DESCRIPTION
## Proposed changes

When trying to rebuild my local quinn dev env from the `planning-1.0-release` Makefile & pyproject.toml, there's a problem -
```
λ git kunaljubce/add-decorators-for-functions-r1.0 → make install_deps 

Group(s) not found: linting (via --with)
make: *** [install_deps] Error 1
```
Problem is with `@poetry install --with=development,linting,testing,docs` in Makefile and there NOT being any dependency group named linting in the [project.toml](https://github.com/mrpowers-io/quinn/blob/planning-1.0-release/pyproject.toml).

## Types of changes

What types of changes does your code introduce to quinn?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

## Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...